### PR TITLE
Add sample fake continuous hardware config

### DIFF
--- a/pycmds/fake-continuous-hardware-config.toml
+++ b/pycmds/fake-continuous-hardware-config.toml
@@ -1,0 +1,10 @@
+[d1]
+port=39001
+units="mm"
+limits=[0,50]
+velocity=10
+[d2]
+port=39002
+units="mm"
+limits=[0,300]
+velocity=50


### PR DESCRIPTION
To use, copy paste this config into the config file (`yaqd edit-config fake-continuous-hardware`) then run the fake-continuous hardware daemons.