### PR TITLE
Provide terminal feedback when a sensor is busy

### DIFF
--- a/yaqc_cmds/sensors/_sensors.py
+++ b/yaqc_cmds/sensors/_sensors.py
@@ -125,6 +125,7 @@ class Sensor(pc.Hardware):
 
     def wait_until_still(self):
         while self.busy.read():
+            print(f"{self.name} is busy")
             self.busy.wait_for_update()
 
 
@@ -153,6 +154,8 @@ class Driver(pc.Driver):
         while self.freerun.read() and not self.enqueued.read():
             self.measure()
             self.busy.write(False)
+            # Rate limit when just freerunning
+            time.sleep(0.1)
 
     def measure(self):
         timer = wt.kit.Timer(verbose=False)


### PR DESCRIPTION
Particularly because a sensor that is stuck busy at startup prevents the app from actually starting. It is nontrivial to properly fix it, but there was zero feedback to alert users as to how to fix the issue. This is a bandaid at best, but better than zero feedback, I guess.

Also puts a rate limit on freerunning because CPU is pegged without one, and now you can actually read the number as it is freerunning.