### PR TITLE
Use raw h5py for live plotting

### DIFF
--- a/yaqc_cmds/_plot.py
+++ b/yaqc_cmds/_plot.py
@@ -110,7 +110,7 @@ class GUI(QtCore.QObject):
 
     def on_axis_updated(self):
         axis = self.data[self.axis.read()]
-        units = axis.attrs["units"]
+        units = axis.attrs.get("units")
         units = [units] + list(wt.units.get_valid_conversions(units))
         self.axis_units.set_allowed_values(units)
 
@@ -129,7 +129,7 @@ class GUI(QtCore.QObject):
         x_units = self.axis_units.read()
         idx = last_idx_written
         axis = self.data[self.axis.read()]
-        limits = list(wt.units.convert([np.min(axis), np.max(axis)], axis.attrs["units"], x_units))
+        limits = list(wt.units.convert([np.min(axis), np.max(axis)], axis.attrs.get("units"), x_units))
         channel = self.data[self.channel.read()]
         plot_idx = list(last_idx_written + (0,) * (channel.ndim - len(last_idx_written)))
         for i, s in enumerate(axis.shape):
@@ -139,7 +139,7 @@ class GUI(QtCore.QObject):
 
         plot_idx = tuple(plot_idx)
         try:
-            xi = wt.units.convert(axis[plot_idx], axis.attrs["units"], x_units)
+            xi = wt.units.convert(axis[plot_idx], axis.attrs.get("units"), x_units)
             yi = channel[plot_idx]
             self.plot_scatter.setData(xi, yi)
         except (TypeError, ValueError) as e:

--- a/yaqc_cmds/_plot.py
+++ b/yaqc_cmds/_plot.py
@@ -138,7 +138,9 @@ class GUI(QtCore.QObject):
 
         plot_idx = tuple(plot_idx)
         try:
-            xi = wt.units.convert(axis[wt.kit.valid_index(plot_idx, axis.shape)], axis.attrs.get("units"), x_units)
+            xi = wt.units.convert(
+                axis[wt.kit.valid_index(plot_idx, axis.shape)], axis.attrs.get("units"), x_units
+            )
             yi = channel[wt.kit.valid_index(plot_idx, channel.shape)]
             self.plot_scatter.setData(xi, yi)
         except (TypeError, ValueError) as e:

--- a/yaqc_cmds/_plot.py
+++ b/yaqc_cmds/_plot.py
@@ -134,15 +134,12 @@ class GUI(QtCore.QObject):
         )
         channel = self.data[self.channel.read()]
         plot_idx = list(last_idx_written + (0,) * (channel.ndim - len(last_idx_written)))
-        for i, s in enumerate(axis.shape):
-            if s == 1:
-                plot_idx[i] = 0
         plot_idx[self.axis.read_index()] = slice(None)
 
         plot_idx = tuple(plot_idx)
         try:
-            xi = wt.units.convert(axis[plot_idx], axis.attrs.get("units"), x_units)
-            yi = channel[plot_idx]
+            xi = wt.units.convert(axis[wt.kit.valid_index(plot_idx, axis.shape)], axis.attrs.get("units"), x_units)
+            yi = channel[wt.kit.valid_index(plot_idx, channel.shape)]
             self.plot_scatter.setData(xi, yi)
         except (TypeError, ValueError) as e:
             print(e)

--- a/yaqc_cmds/_plot.py
+++ b/yaqc_cmds/_plot.py
@@ -129,7 +129,9 @@ class GUI(QtCore.QObject):
         x_units = self.axis_units.read()
         idx = last_idx_written
         axis = self.data[self.axis.read()]
-        limits = list(wt.units.convert([np.min(axis), np.max(axis)], axis.attrs.get("units"), x_units))
+        limits = list(
+            wt.units.convert([np.min(axis), np.max(axis)], axis.attrs.get("units"), x_units)
+        )
         channel = self.data[self.channel.read()]
         plot_idx = list(last_idx_written + (0,) * (channel.ndim - len(last_idx_written)))
         for i, s in enumerate(axis.shape):

--- a/yaqc_cmds/somatic/_wt5.py
+++ b/yaqc_cmds/somatic/_wt5.py
@@ -138,7 +138,7 @@ def create_data(path, headers, destinations, axes, constants, hardware, sensors)
 def get_data_readonly():
     if data_filepath is not None:
         f = h5py.File(data_filepath, "r", libver="latest", swmr=True)
-        return wt.Data(f, edit_local=True)
+        return f
 
 
 def close_data():

--- a/yaqc_cmds/somatic/modules/motortune.py
+++ b/yaqc_cmds/somatic/modules/motortune.py
@@ -92,7 +92,7 @@ class OPA_GUI:
 
 class Worker(acquisition.Worker):
     def process(self, scan_folder):
-        data = _wt5.get_data_readonly().copy()
+        data = wt.Data(_wt5.get_data_readonly()).copy()
         # decide which channels to make plots for
         channel_name = self.aqn.read("processing", "channel")
         # make figures for each channel

--- a/yaqc_cmds/somatic/modules/scan.py
+++ b/yaqc_cmds/somatic/modules/scan.py
@@ -1,6 +1,7 @@
 ### import ####################################################################
 
 import pathlib
+import time
 
 import numpy as np
 
@@ -113,10 +114,10 @@ class Constant:
 class Worker(acquisition.Worker):
     def process(self, scan_folder):
         try:
-            data = _wt5.get_data_readonly().copy()
+            data = wt.Data(_wt5.get_data_readonly()).copy()
         except:
             time.sleep(0.1)
-            data = _wt5.get_data_readonly().copy()
+            data = wt.Data(_wt5.get_data_readonly()).copy()
 
         # decide which channels to make plots for
         main_channel = self.aqn.read("processing", "main channel")


### PR DESCRIPTION
Avoids segfault condition for which the source is probably burried deep within WrightTools, but reaching in directly is easier than solving the wt issues that only present in SWMR cases, for which this is the only real use.


The core of this patch is in tact, but indexing relied on special wt behavior that either needs to be included here (should just be calls to `wt.kit.valid_index`, I think but not 100% sure)

Currently it gets stuck so that the scanned axis (and presumably other inner stepped axes, but haven't experimented much with 3D scans) do not shift properly through the slices (only show the 0 slice)

Also needs some fault tolerance for units being absent, as happens in motortunes.