### PR TITLE
abandon SWMR in favor of context manager lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## Fixed
+- hard crashes caused by multithread access to data, data access now regulated by explicit lock
+
 # [2020.12.1]
 
 ## Fixed

--- a/yaqc_cmds/somatic/_wt5.py
+++ b/yaqc_cmds/somatic/_wt5.py
@@ -2,6 +2,7 @@
 
 
 import time
+import threading
 
 import h5py
 import WrightTools as wt
@@ -10,9 +11,22 @@ import yaqc_cmds.project.project_globals as g
 import yaqc_cmds.somatic as somatic
 
 
-data = None
-data_filepath = None
-last_idx_written = None
+class DataContainer(object):
+    def __init__(self):
+        self.data = None
+        self.data_filepath = None
+        self.last_idx_written = None
+        self.lock = threading.RLock()
+
+    def __enter__(self):
+        self.lock.acquire()
+        return self.data
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.lock.release()
+
+
+data_container = DataContainer()
 
 
 def create_data(path, headers, destinations, axes, constants, hardware, sensors):
@@ -36,127 +50,123 @@ def create_data(path, headers, destinations, axes, constants, hardware, sensors)
         all active sensors
     """
     f = h5py.File(path, "w", libver="latest")
-    global data, data_filepath
-    data = wt.Data(f, name=headers["name"], edit_local=True)
-    data_filepath = path
+    global data_container
+    with data_container as data:
 
-    # fill out yaqc_cmds_information in headers
-    headers["Yaqc_cmds version"] = g.version.read()
-    headers["system name"] = g.system_name.read()
+        if data_container.data is not None:
+            data_container.data.close()
+            data_container.data = None
 
-    data.attrs.update(headers)
+        data = wt.Data(f, name=headers["name"], edit_local=True)
+        data_container.data_filepath = path
 
-    full_scan_shape = tuple(a.points.size for a in axes)
-    variable_shapes = {"labtime": full_scan_shape}
-    variable_units = {"labtime": "s"}
-    variable_labels = {}
+        # fill out yaqc_cmds_information in headers
+        headers["Yaqc_cmds version"] = g.version.read()
+        headers["system name"] = g.system_name.read()
 
-    for i, axis in enumerate(axes):
-        shape = [1] * len(axes)
-        shape[i] = axis.points.size
-        variable_shapes[f"{axis.name}_points"] = tuple(shape)
-        variable_units[f"{axis.name}_points"] = axis.units
-        if hasattr(axis, "centers"):
-            shape = list(full_scan_shape)
-            shape[i] = 1
-            variable_shapes[f"{axis.name}_centers"] = tuple(shape)
-            variable_units[f"{axis.name}_centers"] = axis.units
+        data.attrs.update(headers)
 
-    for hw in hardware:
-        for rec, (_, units, _, label, _) in hw.recorded.items():
-            variable_shapes[rec] = full_scan_shape
-            variable_units[rec] = units
-            variable_labels[rec] = label
+        full_scan_shape = tuple(a.points.size for a in axes)
+        variable_shapes = {"labtime": full_scan_shape}
+        variable_units = {"labtime": "s"}
+        variable_labels = {}
 
-    channel_shapes = {}
-    channel_units = {}
+        for i, axis in enumerate(axes):
+            shape = [1] * len(axes)
+            shape[i] = axis.points.size
+            variable_shapes[f"{axis.name}_points"] = tuple(shape)
+            variable_units[f"{axis.name}_points"] = axis.units
+            if hasattr(axis, "centers"):
+                shape = list(full_scan_shape)
+                shape[i] = 1
+                variable_shapes[f"{axis.name}_centers"] = tuple(shape)
+                variable_units[f"{axis.name}_centers"] = axis.units
 
-    for sensor in sensors:
-        # TODO allow sensors to be inactive
-        # TODO allow multi-D sensors
-        sensor.active = True
+        for hw in hardware:
+            for rec, (_, units, _, label, _) in hw.recorded.items():
+                variable_shapes[rec] = full_scan_shape
+                variable_units[rec] = units
+                variable_labels[rec] = label
 
-        # InGaAs array detector
-        if hasattr(sensor.driver.client, "get_map"):
-            map_shape = full_scan_shape + tuple(sensor.shape)
-            full_scan_shape = full_scan_shape + (1,)
-            for k, v in variable_shapes.items():
-                variable_shapes[k] = v + (1,)
-            for k, v in channel_shapes.items():
-                channel_shapes[k] = v + (1,)
+        channel_shapes = {}
+        channel_units = {}
 
-            variable_shapes["wa"] = map_shape
-            variable_units["wa"] = "nm"
-            variable_labels["wa"] = "a"
+        for sensor in sensors:
+            # TODO allow sensors to be inactive
+            # TODO allow multi-D sensors
+            sensor.active = True
 
-            for ch in sensor.channel_names:
-                channel_shapes[ch] = map_shape
-                channel_units[ch] = None
+            # InGaAs array detector
+            if hasattr(sensor.driver.client, "get_map"):
+                map_shape = full_scan_shape + tuple(sensor.shape)
+                full_scan_shape = full_scan_shape + (1,)
+                for k, v in variable_shapes.items():
+                    variable_shapes[k] = v + (1,)
+                for k, v in channel_shapes.items():
+                    channel_shapes[k] = v + (1,)
 
-        else:
-            for ch in sensor.channel_names:
-                channel_shapes[ch] = full_scan_shape
-                # TODO: channel units?
-                channel_units[ch] = None
+                variable_shapes["wa"] = map_shape
+                variable_units["wa"] = "nm"
+                variable_labels["wa"] = "a"
 
-    for var, sh in variable_shapes.items():
-        units = variable_units[var]
-        label = variable_labels.get(var)
-        if label:
-            data.create_variable(var, shape=sh, units=units, label=label)
-        else:
-            data.create_variable(var, shape=sh, units=units)
+                for ch in sensor.channel_names:
+                    channel_shapes[ch] = map_shape
+                    channel_units[ch] = None
 
-    for axis in axes:
-        sh = data[f"{axis.name}_points"].shape
-        data[f"{axis.name}_points"][:] = axis.points.reshape(sh)
-        if hasattr(axis, "centers"):
-            sh = data[f"{axis.name}_centers"].shape
-            data[f"{axis.name}_centers"][:] = axis.centers.reshape(sh)
+            else:
+                for ch in sensor.channel_names:
+                    channel_shapes[ch] = full_scan_shape
+                    # TODO: channel units?
+                    channel_units[ch] = None
 
-    # This check was originally if there was _centers_ use the points arrays
-    # This was changed to always use the points arrays (except for the array detector)
-    # Because chopping full shaped arrays caused incorrect behavior for 3D+ data
-    # When we have some better hinting in WT itself, this should likely be reverted
-    # KFS 2020-11-13
-    transform = [f"{a.name}_points" if hasattr(a, "points") else a.name for a in axes]
-    if "wa" in variable_shapes:
-        transform += ["wa"]
-    data.transform(*transform)
+        for var, sh in variable_shapes.items():
+            units = variable_units[var]
+            label = variable_labels.get(var)
+            if label:
+                data.create_variable(var, shape=sh, units=units, label=label)
+            else:
+                data.create_variable(var, shape=sh, units=units)
 
-    for ch, sh in channel_shapes.items():
-        units = channel_units[ch]
-        data.create_channel(ch, shape=sh, units=units)
-        # TODO signed?
-        # TODO labels?
+        for axis in axes:
+            sh = data[f"{axis.name}_points"].shape
+            data[f"{axis.name}_points"][:] = axis.points.reshape(sh)
+            if hasattr(axis, "centers"):
+                sh = data[f"{axis.name}_centers"].shape
+                data[f"{axis.name}_centers"][:] = axis.centers.reshape(sh)
 
-    f.swmr_mode = True
-    f.flush()
-    somatic.signals.data_file_created.emit()
+        # This check was originally if there was _centers_ use the points arrays
+        # This was changed to always use the points arrays (except for the array detector)
+        # Because chopping full shaped arrays caused incorrect behavior for 3D+ data
+        # When we have some better hinting in WT itself, this should likely be reverted
+        # KFS 2020-11-13
+        transform = [f"{a.name}_points" if hasattr(a, "points") else a.name for a in axes]
+        if "wa" in variable_shapes:
+            transform += ["wa"]
+        data.transform(*transform)
 
+        for ch, sh in channel_shapes.items():
+            units = channel_units[ch]
+            data.create_channel(ch, shape=sh, units=units)
+            # TODO signed?
+            # TODO labels?
 
-def get_data_readonly():
-    if data_filepath is not None:
-        f = h5py.File(data_filepath, "r", libver="latest", swmr=True)
-        return f
-
-
-def close_data():
-    data.close()
+        data_container.data = data
+        somatic.signals.data_file_created.emit()
 
 
 def write_data(idx, hardware, sensors):
-    in_idx = idx
-    idx = idx + (...,)
-    data["labtime"][idx] = time.time()
-    for hw in hardware:
-        for rec, (obj, *_) in hw.recorded.items():
-            data[rec][idx] = obj.read(data[rec].units)
-    for s in sensors:
-        for ch, val in s.channels.items():
-            data[ch][idx] = val
-        if s.shape[0] > 1:
-            data["wa"][idx] = s.driver.client.get_map(data["wm"][idx])
-    data.flush()
-    global last_idx_written
-    last_idx_written = in_idx
+    global data_container
+    with data_container as data:
+        in_idx = idx
+        idx = idx + (...,)
+        data["labtime"][idx] = time.time()
+        for hw in hardware:
+            for rec, (obj, *_) in hw.recorded.items():
+                data[rec][idx] = obj.read(data[rec].units)
+        for s in sensors:
+            for ch, val in s.channels.items():
+                data[ch][idx] = val
+            if s.shape[0] > 1:
+                data["wa"][idx] = s.driver.client.get_map(data["wm"][idx])
+        data.flush()
+        data_container.last_idx_written = in_idx

--- a/yaqc_cmds/somatic/_wt5.py
+++ b/yaqc_cmds/somatic/_wt5.py
@@ -1,4 +1,4 @@
-"""bwt5 data file functions"""
+"""wt5 data file functions"""
 
 
 import time

--- a/yaqc_cmds/somatic/acquisition.py
+++ b/yaqc_cmds/somatic/acquisition.py
@@ -32,7 +32,7 @@ import yaqc_cmds.hardware.delays as delays
 import yaqc_cmds.hardware.opas as opas
 import yaqc_cmds.hardware.filters as filters
 
-from yaqc_cmds.somatic._wt5 import create_data, write_data, close_data
+from yaqc_cmds.somatic._wt5 import create_data, write_data
 from yaqc_cmds.somatic.order import ndindex as order
 from .signals import data_file_written
 
@@ -297,7 +297,6 @@ class Worker(QtCore.QObject):
                 self.stopped.write(True)
                 break
         # finish scan ---------------------------------------------------------
-        close_data()
         self.fraction_complete.write(1.0)
         self.going.write(False)
         g.queue_control.write(False)

--- a/yaqc_cmds/somatic/modules/motortune.py
+++ b/yaqc_cmds/somatic/modules/motortune.py
@@ -92,11 +92,11 @@ class OPA_GUI:
 
 class Worker(acquisition.Worker):
     def process(self, scan_folder):
-        with yaqc_cmds.somatic._wt5.data_container as data:
+        with _wt5.data_container as data:
             # decide which channels to make plots for
             channel_name = self.aqn.read("processing", "channel")
             # make figures for each channel
-            data_path = pathlib.Path(_wt5.data_filepath)
+            data_path = pathlib.Path(_wt5.data_container.data_filepath)
             data_folder = data_path.parent
             # make all images
             channel_path = data_folder / channel_name

--- a/yaqc_cmds/somatic/modules/motortune.py
+++ b/yaqc_cmds/somatic/modules/motortune.py
@@ -92,39 +92,39 @@ class OPA_GUI:
 
 class Worker(acquisition.Worker):
     def process(self, scan_folder):
-        data = wt.Data(_wt5.get_data_readonly()).copy()
-        # decide which channels to make plots for
-        channel_name = self.aqn.read("processing", "channel")
-        # make figures for each channel
-        data_path = pathlib.Path(_wt5.data_filepath)
-        data_folder = data_path.parent
-        # make all images
-        channel_path = data_folder / channel_name
-        output_path = data_folder
-        if data.ndim > 2:
-            output_path = channel_path
-            channel_path.mkdir()
-        image_fname = channel_name
-        if data.ndim == 1:
-            outs = wt.artists.quick1D(
-                data,
-                channel=channel_name,
-                autosave=True,
-                save_directory=output_path,
-                fname=image_fname,
-                verbose=False,
-            )
-        else:
-            outs = wt.artists.quick2D(
-                data,
-                -1,
-                -2,
-                channel=channel_name,
-                autosave=True,
-                save_directory=output_path,
-                fname=image_fname,
-                verbose=False,
-            )
+        with yaqc_cmds.somatic._wt5.data_container as data:
+            # decide which channels to make plots for
+            channel_name = self.aqn.read("processing", "channel")
+            # make figures for each channel
+            data_path = pathlib.Path(_wt5.data_filepath)
+            data_folder = data_path.parent
+            # make all images
+            channel_path = data_folder / channel_name
+            output_path = data_folder
+            if data.ndim > 2:
+                output_path = channel_path
+                channel_path.mkdir()
+            image_fname = channel_name
+            if data.ndim == 1:
+                outs = wt.artists.quick1D(
+                    data,
+                    channel=channel_name,
+                    autosave=True,
+                    save_directory=output_path,
+                    fname=image_fname,
+                    verbose=False,
+                )
+            else:
+                outs = wt.artists.quick2D(
+                    data,
+                    -1,
+                    -2,
+                    channel=channel_name,
+                    autosave=True,
+                    save_directory=output_path,
+                    fname=image_fname,
+                    verbose=False,
+                )
         # get output image
         if len(outs) == 1:
             output_image_path = outs[0]


### PR DESCRIPTION
We've been having a lot of hard crashes lately. I believe these stem from some sort of thread collisions over data access. Until now we have been using our hdf5 objects in SWMR mode [1]. This _should_ work, but it just... doesn't. Part of the complexity comes from the fact that WrightTools doesn't do a particularly good job at dealing with read-only files.

This PR abandons SWMR mode entirely in favor of a simple context manager lock. This lock explicitly enforces threads to access the data object one at a time. I believe this will have minimal performance implications.

[1] https://docs.h5py.org/en/stable/swmr.html

TODO:
- [x] CHANGELOG
- [x] recover functionality for other modules
- [x] (@ddkohler) test on ps system

resolves #343
resolves #344 