### PR TITLE
Apply zero position at start up (set limits)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## Fixed
 - hard crashes caused by multithread access to data, data access now regulated by explicit lock
+- set zero position at initialization time to ensure limits are set
+- handling of zero position units to remove warning
 
 # [2020.12.1]
 


### PR DESCRIPTION
closes #352 closes #353

The key for setting limits is line 48, the rest is a minor change to get rid of the warning, and in case there ever is a delay for which the motor units are not "mm".