### PR TITLE
WIP: Update to remove reliance on unit 'kind'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+- Update for pint version of WrightTools (3.4.0)
+
 ## [2021.1.1]
 
 ### Fixed

--- a/yaqc_cmds/_plot.py
+++ b/yaqc_cmds/_plot.py
@@ -111,7 +111,7 @@ class GUI(QtCore.QObject):
         with somatic._wt5.data_container as data:
             axis = data[self.axis.read()]
             units = axis.attrs.get("units")
-            units = [units] + list(wt.units.get_valid_conversions(units))
+            units = list(wt.units.get_valid_conversions(units))
             self.axis_units.set_allowed_values(units)
 
     def on_data_file_written(self):

--- a/yaqc_cmds/hardware/opas.py
+++ b/yaqc_cmds/hardware/opas.py
@@ -189,7 +189,7 @@ class GUI(hw.GUI):
         self.plot_motor = pc.Combo(allowed_values=self.driver.curve.arrangements[arr].keys())
         self.plot_motor.updated.connect(self.update_plot)
         input_table.add("Motor", self.plot_motor)
-        allowed_values = list(wt.units.energy.keys())
+        allowed_values = list(wt.units.get_valid_conversions("wn"))
         self.plot_units = pc.Combo(
             initial_value=self.driver.native_units, allowed_values=allowed_values
         )

--- a/yaqc_cmds/project/classes.py
+++ b/yaqc_cmds/project/classes.py
@@ -401,11 +401,6 @@ class Number(PyCMDS_Object):
         self.set_control_steps(single_step, decimals)
         # units
         self.units = units
-        self.units_kind = None
-        for kind, dic in wt_units.dicts.items():
-            if self.units in dic.keys():
-                self.units_dic = dic
-                self.units_kind = kind
         # limits
         self.limits = limits
         if self.limits is None:
@@ -525,7 +520,7 @@ class Number(PyCMDS_Object):
     def give_units_combo(self, units_combo_widget):
         self.units_widget = units_combo_widget
         # add items
-        unit_types = list(self.units_dic.keys())
+        unit_types = list(wt_units.get_valid_conversions(self.units))
         self.units_widget.addItems(unit_types)
         # set current item
         self.units_widget.setCurrentIndex(unit_types.index(self.units))

--- a/yaqc_cmds/project/widgets.py
+++ b/yaqc_cmds/project/widgets.py
@@ -244,7 +244,7 @@ class InputTable(QtWidgets.QWidget):
         global_object.give_control(control)
         layout.addWidget(control)
         # units combobox
-        if not global_object.units_kind is None:
+        if not global_object.units is None:
             control.setMinimumWidth(self.width_input - 55)
             control.setMaximumWidth(self.width_input - 55)
             units = QtWidgets.QComboBox()

--- a/yaqc_cmds/somatic/acquisition.py
+++ b/yaqc_cmds/somatic/acquisition.py
@@ -191,15 +191,14 @@ class Worker(QtCore.QObject):
                 expression = constant.expression
                 arr = np.full(arrs[0].shape, np.nan)
                 units = constant.units
-                units_kind = wt.units.kind(units)
                 vals = {}
                 # populate all hardwares not scanned here
                 for hardware in all_hardwares:
-                    if wt.units.kind(hardware.units) == units_kind:
+                    if wt.units.is_valid_conversion(hardware.units, units):
                         vals[hardware.name] = hardware.get_position(units)
                 for idx in np.ndindex(arrs[0].shape):
                     for destination in destinations_list:
-                        if wt.units.kind(destination.units) == units_kind:
+                        if wt.units.is_valid_conversion(hardware.units, units):
                             val = wt.units.converter(
                                 destination.arr[idx], destination.units, units
                             )


### PR DESCRIPTION
This is the companion to wright-group/WrightTools#957

Changes here are pretty minimal, mostly just getting rid of direct usage of the `wt.units.dicts` and `kind` (preferring function calls)