### PR TITLE
Update for string based has-turret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 - Update for pint version of WrightTools (3.4.0)
+- Use string based update of has-turret trait for spectrometers
+
+### Fixed
+- Deprecated Qt function call
 
 ## [2021.1.1]
 

--- a/yaqc_cmds/project/classes.py
+++ b/yaqc_cmds/project/classes.py
@@ -520,7 +520,7 @@ class Number(PyCMDS_Object):
     def give_units_combo(self, units_combo_widget):
         self.units_widget = units_combo_widget
         # add items
-        unit_types = list(wt_units.get_valid_conversions(self.units))
+        unit_types = [self.units] + list(wt_units.get_valid_conversions(self.units))
         self.units_widget.addItems(unit_types)
         # set current item
         self.units_widget.setCurrentIndex(unit_types.index(self.units))

--- a/yaqc_cmds/somatic/queue.py
+++ b/yaqc_cmds/somatic/queue.py
@@ -762,7 +762,7 @@ class GUI(QtCore.QObject):
         labels[-1] = ""
         labels[-2] = ""
         self.table.setHorizontalHeaderLabels(labels)
-        self.table.horizontalHeader().setResizeMode(5, QtWidgets.QHeaderView.Stretch)
+        self.table.horizontalHeader().setSectionResizeMode(5, QtWidgets.QHeaderView.Stretch)
         self.table.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
         for i, width in enumerate(self.table_cols.values()):
             self.table.setColumnWidth(i, width)


### PR DESCRIPTION
This is a pretty minimal implementation. I hope to get a fuller use of the `fields` provided by the latest versions of yaq, but this is the stopgap "keep it working"

The other two lines of change were to prevent bugs uncovered in testing with particular combinations of our deps (qt/wt). which prevent the program from starting entirely