### PR TITLE
Support for non-triggered sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- support for sensors without `has-measure-trigger` trait
+
 ### Changed
 - Update for pint version of WrightTools (3.4.0)
 - Use string based update of has-turret trait for spectrometers

--- a/yaqc_cmds/sensors/_sensors.py
+++ b/yaqc_cmds/sensors/_sensors.py
@@ -162,9 +162,10 @@ class Driver(pc.Driver):
         timer = wt.kit.Timer(verbose=False)
         with timer:
             self.busy.write(True)
-            self.client.measure(loop=False)
-            while self.client.busy():
-                time.sleep(0.01)
+            if "has-measure-trigger" in self.client.traits:
+                self.client.measure(loop=False)
+                while self.client.busy():
+                    time.sleep(0.01)
             out = self.client.get_measured()
             del out["measurement_id"]
             signed = [False for _ in out]


### PR DESCRIPTION
will allow us to configure mqtt sensors in lab

I also made it so that non-triggered sensors do not wait for "busy" to be done, under the assumption that since they are not triggered waiting is likely either not needed or actively the wrong thing to do (if a sensor like this takes _seconds_ to do a measurement where it registers as busy, no need to hold up the scan)