### PR TITLE
Implementation of has-mapping sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 - support for sensors without `has-measure-trigger` trait
+- support for sensors that implement `has-mapping` trait
 
 ### Changed
 - Update for pint version of WrightTools (3.4.0)

--- a/yaqc_cmds/_plot.py
+++ b/yaqc_cmds/_plot.py
@@ -95,8 +95,6 @@ class GUI(QtCore.QObject):
 
     def on_channels_changed(self):
         new = list(sensors.get_channels_dict())
-        if "ingaas" in new:
-            new.remove("ingaas")
         self.channel.set_allowed_values(new)
 
     def on_data_file_created(self):

--- a/yaqc_cmds/_plot.py
+++ b/yaqc_cmds/_plot.py
@@ -109,7 +109,7 @@ class GUI(QtCore.QObject):
         with somatic._wt5.data_container as data:
             axis = data[self.axis.read()]
             units = axis.attrs.get("units")
-            units = list(wt.units.get_valid_conversions(units))
+            units = [units] + list(wt.units.get_valid_conversions(units))
             self.axis_units.set_allowed_values(units)
 
     def on_data_file_written(self):
@@ -124,7 +124,7 @@ class GUI(QtCore.QObject):
             axis = data[self.axis.read()]
             limits = list(
                 wt.units.convert(
-                    [np.min(axis.full), np.max(axis.full)], axis.attrs.get("units"), x_units
+                    [np.nanmin(axis.full), np.nanmax(axis.full)], axis.attrs.get("units"), x_units
                 )
             )
             channel = data[self.channel.read()]
@@ -147,7 +147,8 @@ class GUI(QtCore.QObject):
             try:
                 self.plot_widget.set_xlim(min(limits), max(limits))
                 self.plot_widget.set_ylim(np.min(channel), np.max(channel))
-            except Exception:
+            except Exception as e:
+                print(e)
                 pass
 
     def on_sensors_changed(self):

--- a/yaqc_cmds/sensors/_sensors.py
+++ b/yaqc_cmds/sensors/_sensors.py
@@ -168,6 +168,11 @@ class Driver(pc.Driver):
                     time.sleep(0.01)
             out = self.client.get_measured()
             del out["measurement_id"]
+            try:
+                del out["mapping_id"]
+            except KeyError:
+                # No mapping
+                pass
             signed = [False for _ in out]
             self.data.write_properties(self.shape, out, signed)
             self.busy.write(False)

--- a/yaqc_cmds/somatic/modules/scan.py
+++ b/yaqc_cmds/somatic/modules/scan.py
@@ -125,12 +125,24 @@ class Worker(acquisition.Worker):
             for channel_name in channels:
                 channel_path = data_folder / channel_name
                 output_path = data_folder
-                if data.ndim > 2:
+                orig_transform = data.axis_names
+                print(data.axis_names)
+                axes = []
+                for a in orig_transform:
+                    print(data[channel_name].shape, data[a].shape)
+                    if all(
+                        ch_sh >= a_sh
+                        for ch_sh, a_sh in zip(data[channel_name].shape, data[a].shape)
+                    ):
+                        axes.append(a)
+                data.transform(*axes)
+                print(data.axis_names)
+                if sum(a > 1 for a in data[channel_name].shape) > 2:
                     output_path = channel_path
                     channel_path.mkdir()
                 channel_index = data.channel_names.index(channel_name)
                 image_fname = channel_name
-                if data.ndim == 1:
+                if sum(a > 1 for a in data[channel_name].shape) == 1:
                     outs = wt.artists.quick1D(
                         data,
                         channel=channel_index,
@@ -152,6 +164,7 @@ class Worker(acquisition.Worker):
                     )
                 if channel_name == main_channel:
                     outputs = outs
+                data.transform(*orig_transform)
             # get output image
             if len(outputs) == 1:
                 output_image_path = outputs[0]


### PR DESCRIPTION
This is _most_ of the way there, I believe (having only tested with the fake-spectrometer class)

Note:

- fake spectrometer needs to implement the channel_shape, which was not done previously (about to MR that)
- very little optimization for things like the ocean optics, which have purely static maps which could in theory just be recorded as squeezed ndim =1 variables... all mappings are read every pixel (I do not cache by mapping id, e.g. either)

Currently file writing works perfectly as far as I can tell, but the presence of a has-mapping sensor messes with the autogenerated plot (when the channel in question does not span the axes), so scans "fail" even though the file is written properly

should be relatively easy to solve, but that is a tomorrow problem