### PR TITLE
Fix autonomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Fixed
 - Ensure float passed in `set_position_except` (rather than scalar ndarray)
 - Motortune collecting tune points with discrete tunes
+- Better consistency of autonomic system
 
 ## [2021.3.0]
 

--- a/yaqc_cmds/autonomic/coset.py
+++ b/yaqc_cmds/autonomic/coset.py
@@ -111,13 +111,12 @@ class CoSetHW:
         for control in self.instrument.arrangements.keys():
             if not self.control_arrangement_bools[control].read():
                 continue
-            position = all_hardwares[control].get_position(all_hardwares[control].native_units)
-            note = self.instrument(position, arrangement_name=control)
+            position = all_hardwares[control].get_destination(all_hardwares[control].native_units)
             try:
                 key = all_hardwares[control].driver.client.get_arrangement()
-                new += note[key]
             except Exception as e:  # TODO: better exception handling
-                new += note["auto"]  # default key
+                key = "auto"
+            new += self.instrument[control][key](position)
         if g.hardware_initialized.read():
             self.hardware.set_offset(new, self.hardware.native_units)
 


### PR DESCRIPTION
There were two problems addressed here

First if multiple arrangements have cosets, attune may reject the control as valid, so index into the tune before evaluating. 

Second: sets were lagging behind the correct setpoint, so caclulate off of destination rather than current position