### PR TITLE
Add ihr Widgets, some small fixes needed on Waldo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Motortune collecting tune points with discrete tunes
 - Better consistency of autonomic system
 - Ensure correct units used in acquisition
+- axes with whitespace don't necessarily fail
+- Motortune Tunepoints only calculated if the checkbox is checked
+- old "identity" behavior removed which caused splitting on "F" in axis names
+
+### Added
+- Widgets to control slit widths and mirror positions of monochromator
 
 ## [2021.3.0]
 

--- a/yaqc_cmds/_plot.py
+++ b/yaqc_cmds/_plot.py
@@ -99,7 +99,7 @@ class GUI(QtCore.QObject):
 
     def on_data_file_created(self):
         with somatic._wt5.data_container as data:
-            allowed = [x.split()[0] for x in data.attrs["axes"]]
+            allowed = [x.split("{")[0].strip() for x in data.attrs["axes"]]
             if "wa" in allowed:
                 allowed.remove("wa")
             self.axis.set_allowed_values(allowed)

--- a/yaqc_cmds/hardware/spectrometers.py
+++ b/yaqc_cmds/hardware/spectrometers.py
@@ -3,7 +3,9 @@
 
 import yaqc_cmds.__main__
 import yaqc_cmds.project.classes as pc
+import yaqc_cmds.project.widgets as pw
 import yaqc_cmds.hardware.hardware as hw
+import yaqc_cmds.project.project_globals as g
 import pathlib
 import appdirs
 import toml
@@ -28,19 +30,18 @@ class Driver(hw.Driver):
         self.recorded[self.name] = [self.position, self.native_units, 1.0, "m", False]
         self.limits.write(*self.ctrl.get_limits())
         self.wait_until_still()
-        # finish
-        self.initialized.write(True)
-        self.initialized_signal.emit()
 
         self.grating = pc.Combo(
             name="Grating",
             allowed_values=self.ctrl.get_turret_options(),
-            section=self.name,
-            option="grating",
             display=True,
             set_method="set_turret",
         )
         self.exposed.append(self.grating)
+
+        # finish
+        self.initialized.write(True)
+        self.initialized_signal.emit()
 
     def get_position(self):
         native_position = self.ctrl.get_position()
@@ -62,12 +63,130 @@ class Driver(hw.Driver):
         self.wait_until_still()
         self.limits.write(*self.ctrl.get_limits(), self.native_units)
 
+    def set_exit_mirror(self, destination):
+        if type(destination) == list:
+            destination = destination[0]
+        self.ctrl.set_exit_mirror(destination)
+        self.hardware.exit_mirror.write(destination)
+
+    def set_entrance_mirror(self, destination):
+        if type(destination) == list:
+            destination = destination[0]
+        self.ctrl.set_entrance_mirror(destination)
+        self.hardware.entrance_mirror.write(destination)
+
+    def set_front_entrance_slit(self, destination):
+        self.ctrl.set_front_entrance_slit(float(destination))
+        self.hardware.front_entrance_slit.write(destination)
+
+    def set_side_entrance_slit(self, destination):
+        self.ctrl.set_side_entrance_slit(float(destination))
+        self.hardware.side_entrance_slit.write(destination)
+
+    def set_front_exit_slit(self, destination):
+        self.ctrl.set_front_exit_slit(float(destination))
+        self.hardware.front_exit_slit.write(destination)
+
+    def set_side_exit_slit(self, destination):
+        self.ctrl.set_side_exit_slit(float(destination))
+        self.hardware.side_exit_slit.write(destination)
+
 
 ### gui #######################################################################
 
 
 class GUI(hw.GUI):
-    pass
+    def initialize(self):
+        super().initialize()
+        # self.layout.addWidget(self.scroll_area)
+        # attributes
+        mirror_list = ["front", "side"]
+        input_table = pw.InputTable()
+        self.scroll_layout.addWidget(pw.line("H"))
+
+        has_mirror = False
+        if hasattr(self.driver.ctrl, "set_entrance_mirror"):
+            has_mirror = True
+            input_table.add("Entrance Mirror", None)
+            input_table.add("Current", self.hardware.entrance_mirror)
+            self.entrance_mirror_dest = self.hardware.entrance_mirror.associate(display=False)
+            input_table.add("Destination", self.entrance_mirror_dest)
+        if hasattr(self.driver.ctrl, "set_exit_mirror"):
+            has_mirror = True
+            input_table.add("Exit Mirror", None)
+            input_table.add("Current", self.hardware.exit_mirror)
+            self.exit_mirror_dest = self.hardware.exit_mirror.associate(display=False)
+            input_table.add("Destination", self.exit_mirror_dest)
+
+        if has_mirror:
+            self.scroll_layout.addWidget(input_table)
+            input_table = pw.InputTable()
+            self.set_mirror_button = pw.SetButton("SET MIRRORS")
+            self.scroll_layout.addWidget(self.set_mirror_button)
+            self.set_mirror_button.clicked.connect(self.on_set_mirror)
+            g.queue_control.disable_when_true(self.set_mirror_button)
+            self.scroll_layout.addWidget(pw.line("H"))
+
+        has_slit = False
+        if hasattr(self.driver.ctrl, "set_front_entrance_slit"):
+            has_slit = True
+            input_table.add("Front Entrance Slit", None)
+            input_table.add("Current", self.hardware.front_entrance_slit)
+            self.front_entrance_slit_dest = self.hardware.front_entrance_slit.associate(
+                display=False
+            )
+            input_table.add("Destination", self.front_entrance_slit_dest)
+        if hasattr(self.driver.ctrl, "set_side_entrance_slit"):
+            has_slit = True
+            input_table.add("Side Entrance Slit", None)
+            input_table.add("Current", self.hardware.side_entrance_slit)
+            self.side_entrance_slit_dest = self.hardware.side_entrance_slit.associate(
+                display=False
+            )
+            input_table.add("Destination", self.side_entrance_slit_dest)
+        if hasattr(self.driver.ctrl, "set_front_exit_slit"):
+            has_slit = True
+            input_table.add("Front Exit Slit", None)
+            input_table.add("Current", self.hardware.front_exit_slit)
+            self.front_exit_slit_dest = self.hardware.front_exit_slit.associate(display=False)
+            input_table.add("Destination", self.front_exit_slit_dest)
+        if hasattr(self.driver.ctrl, "set_side_exit_slit"):
+            has_slit = True
+            input_table.add("Side Exit Slit", None)
+            input_table.add("Current", self.hardware.side_exit_slit)
+            self.side_exit_slit_dest = self.hardware.side_exit_slit.associate(display=False)
+            input_table.add("Destination", self.side_exit_slit_dest)
+        if has_slit:
+            self.scroll_layout.addWidget(input_table)
+            self.set_slit_button = pw.SetButton("SET SLITS")
+            self.scroll_layout.addWidget(self.set_slit_button)
+            self.set_slit_button.clicked.connect(self.on_set_slit)
+            g.queue_control.disable_when_true(self.set_slit_button)
+            self.scroll_layout.addWidget(pw.line("H"))
+
+    def on_set_mirror(self):
+        entrance = self.entrance_mirror_dest.read()
+        self.driver.set_entrance_mirror(entrance)
+        exit = self.exit_mirror_dest.read()
+        self.driver.set_exit_mirror(exit)
+        self.driver.get_position()
+        self.driver.save_status()
+
+    def on_set_slit(self):
+        front_entrance = self.front_entrance_slit_dest.read("mm")
+        self.driver.set_front_entrance_slit(front_entrance)
+
+        side_entrance = self.side_entrance_slit_dest.read("mm")
+        self.driver.set_side_entrance_slit(side_entrance)
+
+        front_exit = self.front_exit_slit_dest.read("mm")
+        self.driver.set_front_exit_slit(front_exit)
+
+        side_exit = self.side_exit_slit_dest.read("mm")
+        self.driver.set_side_exit_slit(side_exit)
+
+        self.driver.get_position()
+        self.driver.save_status()
 
 
 ### hardware ##################################################################
@@ -76,6 +195,20 @@ class GUI(hw.GUI):
 class Hardware(hw.Hardware):
     def __init__(self, *args, **kwargs):
         self.kind = "spectrometer"
+        mirror_list = ["front", "side"]
+        self.entrance_mirror = pc.Combo(
+            allowed_values=mirror_list,
+            display=True,
+        )
+        self.exit_mirror = pc.Combo(
+            allowed_values=mirror_list,
+            display=True,
+        )
+        self.slit_limits = pc.NumberLimits(min_value=0, max_value=7, units="mm")
+        self.front_entrance_slit = pc.Number(limits=self.slit_limits, units="mm", display=True)
+        self.front_exit_slit = pc.Number(limits=self.slit_limits, units="mm", display=True)
+        self.side_entrance_slit = pc.Number(limits=self.slit_limits, units="mm", display=True)
+        self.side_exit_slit = pc.Number(limits=self.slit_limits, units="mm", display=True)
         hw.Hardware.__init__(self, *args, **kwargs)
 
 

--- a/yaqc_cmds/somatic/acquisition.py
+++ b/yaqc_cmds/somatic/acquisition.py
@@ -60,7 +60,7 @@ class Axis:
         # fill hardware dictionary with defaults
         # Not sure if this re.split does what we want now, getting rid of identity
         # KFS 200-10-13
-        names = re.split("[=F]+", self.name)
+        names = re.split("=+", self.name)
         for name in names:
             if name not in self.hardware_dict.keys():
                 hardware_object = next(h for h in all_hardwares if h.name == name)

--- a/yaqc_cmds/somatic/modules/motortune.py
+++ b/yaqc_cmds/somatic/modules/motortune.py
@@ -147,10 +147,11 @@ class Worker(acquisition.Worker):
         arrangement = opa_hardware.curve.arrangements[opa_hardware.arrangement]
         motor_names = self.aqn.read("motortune", "motor names")
         scanned_motors = [m for m in motor_names if self.aqn.read(m, "method") == "Scan"]
-        tune_points = get_tune_points(curve, arrangement, scanned_motors)
+
         tune_units = "nm"  # needs update if/when attune supports other units for independents
         # tune points
         if self.aqn.read("motortune", "use tune points"):
+            tune_points = get_tune_points(curve, arrangement, scanned_motors)
             motors_excepted = []  # list of indicies
             for motor_name in motor_names:
                 if not self.aqn.read(motor_name, "method") == "Set":


### PR DESCRIPTION
In an ideal world this would be broken up into at least 2 PRs, but all of these changes happened in short succession without actually PRing, and this is just easier than teasing them apart

Major change is the addition of widgets to set mirror and slit positions of the monochromator, if the methods exist on the client.

Minor changes:

- axes with whitespace don't necessarily fail, though we also adjusted waldo to use underscores instead of spaces anyway.
- Motortune Tunepoints only calculated if the checkbox is checked
- old "identity" behavior removed which caused splitting on "F" in axis names